### PR TITLE
Ft24-1: Run Integration Tests against Specific Version of Function via API Gateway

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+⚠️⚠️ ⚠️ All PRs must have a version of the format `pr${number}` and an override target url set up on the user-accout-test api ⚠️ ⚠️ ⚠️
 ## Purpose
 <!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
 * ...

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,5 +128,5 @@ stages:
             displayName: Retrieve Stashed Artefacts
           - script: |
               cd ./integration-tests
-              npm test -- --world-parameters {\"baseFunctionUri\":\"https://mathdojoio.cloud.tyk.io/user-account-service-np-test/api\",\"apiKey\":\"\"}
+              npm test -- --world-parameters {\"baseFunctionUri\":\"https://mathdojoio.cloud.tyk.io/user-account-service-np-test/api\",\"apiKey\":\"\", \"xApiVersion\":\"$(functionAppName)\"}
             displayName: Exec Npm Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ stages:
       ${{ if eq(variables['Build.Reason'], 'PullRequest') }}: 
         functionAppName: "pr$(System.PullRequest.PullRequestNumber)"
       ${{ if not(eq(variables['Build.Reason'], 'PullRequest')) }}: 
-        functionAppName: "pr$(Build.SourceBranchName)"
+        functionAppName: "$(Build.SourceBranchName)"
     jobs:
       - job: Build_and_Exec_Unit_Tests
         steps:
@@ -56,7 +56,7 @@ stages:
       ${{ if eq(variables['Build.Reason'], 'PullRequest') }}: 
         functionAppName: "pr$(System.PullRequest.PullRequestNumber)"
       ${{ if not(eq(variables['Build.Reason'], 'PullRequest')) }}: 
-        functionAppName: "pr$(Build.SourceBranchName)"
+        functionAppName: "$(Build.SourceBranchName)"
     jobs:
       - job: Deploy_App_and_Setup_Monitoring
         steps:
@@ -95,7 +95,7 @@ stages:
       ${{ if eq(variables['Build.Reason'], 'PullRequest') }}: 
         functionAppName: "pr$(System.PullRequest.PullRequestNumber)"
       ${{ if not(eq(variables['Build.Reason'], 'PullRequest')) }}: 
-        functionAppName: "pr$(Build.SourceBranchName)"
+        functionAppName: "$(Build.SourceBranchName)"
     jobs:
       - job: Configure_Function_Parameters
         steps:
@@ -116,7 +116,7 @@ stages:
       ${{ if eq(variables['Build.Reason'], 'PullRequest') }}: 
         functionAppName: "pr$(System.PullRequest.PullRequestNumber)"
       ${{ if not(eq(variables['Build.Reason'], 'PullRequest')) }}: 
-        functionAppName: "pr$(Build.SourceBranchName)"
+        functionAppName: "$(Build.SourceBranchName)"
     condition: eq(variables['Build.Reason'], 'PullRequest')
     jobs:
       - job: Exec_Integration_Tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,5 +128,5 @@ stages:
             displayName: Retrieve Stashed Artefacts
           - script: |
               cd ./integration-tests
-              npm test -- --world-parameters {\"baseFunctionUri\":\"https://mathdojoio.cloud.tyk.io/user-account-service-np-test/api\",\"apiKey\":\"\", \"xApiVersion\":\"$(functionAppName)\"}
+              npm test -- --world-parameters {\"baseFunctionUri\":\"https://mathdojoio.cloud.tyk.io/user-account-service-np-test/api\",\"apiKey\":\"\",\"xApiVersion\":\"$(functionAppName)\"}
             displayName: Exec Npm Test

--- a/integration-tests/features/step_definitions/request_steps.js
+++ b/integration-tests/features/step_definitions/request_steps.js
@@ -20,7 +20,8 @@ When(/I make a (\w+) to the function at \'(.*)\'/, function (httpMethod, path) {
     method: httpMethod,
     validateStatus: function (status) {
       return status >= 200 && status < 503; // default
-    }
+    },
+    headers: this.world.request.headers
   });
 });
 

--- a/integration-tests/features/support/payloads.js
+++ b/integration-tests/features/support/payloads.js
@@ -35,7 +35,7 @@ module.exports.payloads = {
         invalidParam: "ivalidValue"
     },
     userPermissionsModificationRequest: {
-        permissions: ["consumer", "creator"]
+        permissions: ["CONSUMER", "CREATOR"]
     },
     badUserPermissionsModificationRequest: {
         invalidParam: "ivalidValue",

--- a/integration-tests/features/support/world.js
+++ b/integration-tests/features/support/world.js
@@ -12,6 +12,7 @@ class CustomWorld {
     this.world.request = {};
     this.world.request.headers = {};
     this.world.request.headers.apiKey = parameters.apiKey ? parameters.apiKey: "";
+    this.world.request.headers["X-Api-Version"] = parameters.xApiVersion ? parameters.xApiVersion: "";
     this.world.request.body = {};
     this.world.response = new Promise((resolve, reject) => {});
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Currently the test API exposed for integration tests has a fixed upstream target. This PR enables the inclusion of an `x-api-version` header that specifies the target Azure Function App Url.




## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[X] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
The integration tests should show the inclusion of this value via the command that starts them on the azure pipeline
```

## What to Check
Verify that the following are valid
* Requests to https://mathdojoio.cloud.tyk.io/user-account-service-np-test/ without a version return 403 (via postman)
* Requests to https://mathdojoio.cloud.tyk.io/user-account-service-np-test/ with an `X-Api-Version` header give the expected code (can also be checked via postman or just from the results of the test run on the pipeline)

## Other Information
<!-- Add any other helpful information that may be needed here. -->
#### Static Config on API Gateway:
![image](https://user-images.githubusercontent.com/20339399/95428162-8b9fe180-0940-11eb-85cf-29ec55662987.png)

#### Dynamic Config
![image](https://user-images.githubusercontent.com/20339399/95428365-d588c780-0940-11eb-82b6-1945c8035dae.png)
