### PR TITLE
Ft24-2: Fix Errors in Local Integration Run on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,10 +54,6 @@ stages:
         variables:
           - template: environments/local.yml
         steps:
-          - task: DownloadPipelineArtifact@2
-            inputs:
-              artifact: workingDir
-              path: $(System.DefaultWorkingDirectory)
           - script: |
               npm i -g azure-functions-core-tools@3 --unsafe-perm true
             displayName: Install Azure Func Core Tools

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ stages:
               path: $(System.DefaultWorkingDirectory)
               artifact: workingDir
           - script: |
-              cd ./integration-tests
+              cd ./integration-tests && npm i -g azure-functions-core-tools@3 --unsafe-perm true
               npm run pretest && npm run local:test:windows
             displayName: Run Local Integration Tests
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,10 @@ stages:
               path: $(System.DefaultWorkingDirectory)
               artifact: workingDir
           - script: |
-              cd ./integration-tests && npm i -g azure-functions-core-tools@3 --unsafe-perm true
+              npm i -g azure-functions-core-tools@3 --unsafe-perm true
+            displayName: Install Azure Func Core Tools
+          - script: |
+              cd ./integration-tests
               npm run pretest && npm run local:test:windows
             displayName: Run Local Integration Tests
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,11 @@ stages:
           - script: |
               npm i -g azure-functions-core-tools@3 --unsafe-perm true
             displayName: Install Azure Func Core Tools
+          - bash: |
+              echo "##vso[task.setvariable variable=MATH_DOJO_ENV_NAME]local"
+              echo "##vso[task.setvariable variable=MATH_DOJO_HTTP_REQUEST_SIGNATURE_EXPECTED_KEYID]"
+              echo "##vso[task.setvariable variable=MATH_DOJO_HTTP_REQUEST_SIGNATURE_B64_DER_PUBLIC_KEY]"
+              displayName: Temporarily Set App Vars for Local
           - script: |
               cd ./integration-tests
               npm run pretest && npm run local:test:windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,11 @@ stages:
           - script: |
               mvnw -DfunctionAppName=user-account-service-$(functionAppName) clean package
             displayName: Build package
+          - script: |
+              cd ./integration-tests
+              npm run pretest
+              npm run local:test:windows
+            displayName: Run Local Integration Tests
           - task: PublishPipelineArtifact@1
             inputs:
               path: $(System.DefaultWorkingDirectory)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,10 +50,6 @@ stages:
             inputs:
               path: $(System.DefaultWorkingDirectory)
               artifact: workingDir
-          - script: |
-              cd ./integration-tests
-              npm run pretest && npm run local:test:windows
-            displayName: Run Local Integration Tests
       - job: Local_Integ_Tests
         variables:
           - template: environments/local.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,13 +51,20 @@ stages:
               path: $(System.DefaultWorkingDirectory)
               artifact: workingDir
           - script: |
+              cd ./integration-tests
+              npm run pretest && npm run local:test:windows
+            displayName: Run Local Integration Tests
+      - job: Local_Integ_Tests
+        variables:
+          - template: environments/local.yml
+        steps:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: workingDir
+              path: $(System.DefaultWorkingDirectory)
+          - script: |
               npm i -g azure-functions-core-tools@3 --unsafe-perm true
             displayName: Install Azure Func Core Tools
-          - bash: |
-              echo "##vso[task.setvariable variable=MATH_DOJO_ENV_NAME]local"
-              echo "##vso[task.setvariable variable=MATH_DOJO_HTTP_REQUEST_SIGNATURE_EXPECTED_KEYID]"
-              echo "##vso[task.setvariable variable=MATH_DOJO_HTTP_REQUEST_SIGNATURE_B64_DER_PUBLIC_KEY]"
-              displayName: Temporarily Set App Vars for Local
           - script: |
               cd ./integration-tests
               npm run pretest && npm run local:test:windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,14 +46,14 @@ stages:
           - script: |
               mvnw -DfunctionAppName=user-account-service-$(functionAppName) clean package
             displayName: Build package
-          - script: |
-              cd ./integration-tests
-              npm run pretest && npm run local:test:windows
-            displayName: Run Local Integration Tests
           - task: PublishPipelineArtifact@1
             inputs:
               path: $(System.DefaultWorkingDirectory)
               artifact: workingDir
+          - script: |
+              cd ./integration-tests
+              npm run pretest && npm run local:test:windows
+            displayName: Run Local Integration Tests
 
   - stage: Deploy
     variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,8 +48,7 @@ stages:
             displayName: Build package
           - script: |
               cd ./integration-tests
-              npm run pretest
-              npm run local:test:windows
+              npm run pretest && npm run local:test:windows
             displayName: Run Local Integration Tests
           - task: PublishPipelineArtifact@1
             inputs:

--- a/environments/local.yml
+++ b/environments/local.yml
@@ -1,0 +1,19 @@
+variables:
+- name: MATH_DOJO_ENV_NAME
+  value: 'local'
+  readonly: true
+- name: MATH_DOJO_HTTP_REQUEST_SIGNATURE_EXPECTED_KEYID
+  value: ''
+  readonly: true
+- name: MATH_DOJO_HTTP_REQUEST_SIGNATURE_B64_DER_PUBLIC_KEY
+  value: ''
+  readonly: true
+- name: appInsightsKey
+  value: '847d7f9e-408c-44ec-9bb5-e1f99872d8f2'
+  readonly: true
+- name: APPINSIGHTS_INSTRUMENTATIONKEY
+  value: '847d7f9e-408c-44ec-9bb5-e1f99872d8f2'
+  readonly: true
+- name: appInsightsKey
+  value: '847d7f9e-408c-44ec-9bb5-e1f99872d8f2'
+  readonly: true

--- a/integration-tests/features/support/hooks.js
+++ b/integration-tests/features/support/hooks.js
@@ -31,7 +31,7 @@ BeforeAll({
     console.info("\nTest is not against a locally running function. Skipping function init.\n");
     return;
   }
-  console.info("\nTest is against a locally running function. Skipping function init.\n");
+  console.info("\nTest is against a locally running function. Starting function.\n");
   return new Promise((resolve, reject) => {
     const command = ( process.platform == 'win32' ? 'cmd.exe' : 'bash');
     const mavenScriptToRun = ( process.platform == 'win32' ? 'mvnw' : 'mvnw');
@@ -107,6 +107,13 @@ AfterAll(function() {
     processes.useraccountservice.functionapp.processEventEmitter.stderr.end();
     processes.useraccountservice.functionapp.processEventEmitter.stdout.destroy();
     processes.useraccountservice.functionapp.processEventEmitter.stdin.destroy();
-    execSync('kill $(lsof -t -i :7071)');
+    console.info("Attempting to clean-up any other processes using the function port");
+    if(process.platform == 'win32') {
+      const processName = execSync('netstat -ano | findstr :7071');
+      const processId = (processName.toString().match(/(?:LISTENING\s+)(\d+)/))[1];
+      execSync(`taskkill /F /PID ${processId}`);
+    } else {
+      execSync('kill $(lsof -t -i :7071)');
+    }
   });
 });

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -4,9 +4,12 @@
   "description": "A series of integration tests send HTTP requests to the user-account-service function on port 7071.",
   "scripts": {
     "local:pretest": "cd ../ && ./mvnw clean package",
-    "local:runsuite": "./node_modules/.bin/cucumber-js --world-parameters '{\"baseFunctionUri\":\"http://localhost:7071/api\", \"apiKey\":\"\"}'",
-    "local:runnamedtags": "./node_modules/.bin/cucumber-js --tags \"(@updateUserPermissions)\" --world-parameters '{\"baseFunctionUri\":\"http://localhost:7071/api\", \"apiKey\":\"\"}'",
+    "local:pretest:windows": "cd ../ && .\\mvnw.cmd clean package",
+    "local:runsuite": "./node_modules/.bin/cucumber-js --world-parameters '{\"baseFunctionUri\":\"http://localhost:7071/api\",\"apiKey\":\"\"}'",
+    "local:runsuite:windows": "./node_modules/.bin/cucumber-js --world-parameters {\\\"baseFunctionUri\\\":\\\"http://localhost:7071/api\\\",\\\"apiKey\\\":\\\"\\\"}",
+    "local:runnamedtags": "./node_modules/.bin/cucumber-js --tags \"(@updateUserPermissions)\" --world-parameters '{\"baseFunctionUri\":\"http://localhost:7071/api\",\"apiKey\":\"\"}'",
     "local:test-subset": "npm run local:pretest && npm run local:runnamedtags",
+    "local:test:windows": "npm run local:pretest:windows && npm run local:runsuite:windows",
     "local:test": "npm run local:pretest && npm run local:runsuite",
     "pretest": "npm install --production",
     "test": "./node_modules/.bin/cucumber-js"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* A pre-requisite of the 4th criteria in #24 is the ability of the pipeline to run integration tests on a locally running function within the azure pipeline. This PR fixes previous issues that prevented this from running.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
cd ./integration-tests
npm run local:test:windows
```

## What to Check
Verify that the following are valid
* Integration tests should successfully run in a job on the pipeline, with the following at the bottom of the log.
```sh
Function App stdout: Worker process started and initialized.
Function App stdout: 

Function App stdout: [2020-10-09T07:47:48.766] Listening for transport dt_socket at address: 5005

Function App stdout: Hosting environment: Production
Content root path: D:\a\1\s\target\azure-functions\user-account-service-function

Function App stdout: Now listening on: http://0.0.0.0:7071
Application started. Press Ctrl+C to shut down.

.....................................................................
Test is against a locally running function. Tearing down the function.


Terminating the functions process running with id 4072
Attempting to clean-up any other processes using the function port


24 scenarios (24 passed)
69 steps (69 passed)
0m05.689s

```

* Locally running the tests should yield a similar output

## Other Information
<!-- Add any other helpful information that may be needed here. -->